### PR TITLE
Feature/custom ami for worker

### DIFF
--- a/drone/cloud-config.yaml
+++ b/drone/cloud-config.yaml
@@ -1,39 +1,9 @@
 #cloud-config
 
-# Create the docker group.
-groups:
-  - docker
-
-# Add default auto created user to docker group.
-system_info:
-  default_user:
-    groups: [docker]
-
 # Update and upgrade packages.
 package_upgrade: true
 
 runcmd:
-  # Install pre-requisite packages and Docker.
-  - |
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
-      apt-key add -
-  - |
-    add-apt-repository \
-      "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-  - apt-get update -y
-  - |
-    apt-get install -y \
-      containerd.io \
-      docker-ce \
-      docker-ce-cli \
-      awscli \
-      binutils \
-      s3fs
-
-  # Enable docker service.
-  - systemctl start docker
-  - systemctl enable docker
-
   # Create mount points.
   - export AUTOMATED_TESTING_DIR=/mnt/vault/datasets/abyss-internal/automated-testing
   - |

--- a/drone/cloud-config.yaml
+++ b/drone/cloud-config.yaml
@@ -47,11 +47,11 @@ runcmd:
         $ECR
 
   - |
+    # "echo Hello"
     # "make test"
     # "make test-python-long"
-    # "pytest -m long_test assets/examples/deploy/workflow/tests/test_constitution.py::test_constitution_gold"
     for command in \
-      "echo Hello"
+      "pytest -m long_test assets/examples/deploy/workflow/tests/test_constitution.py::test_constitution_gold"
     do
       container_id=$(
         docker run \
@@ -73,7 +73,7 @@ runcmd:
     done
 
   # cloud-init log files include more detailed logging data.
-  # - cp /var/log/cloud-init* $LOGS_DIR/
+  - cp /var/log/cloud-init* $LOGS_DIR/
 
   # Copy locally generated data to S3 bucket.
   - |

--- a/drone/drone-worker-template.yaml
+++ b/drone/drone-worker-template.yaml
@@ -6,7 +6,7 @@ BlockDeviceMappings:
     VolumeSize: 96
     VolumeType: gp2
     Encrypted: false
-ImageId: ami-08f0bc76ca5236b20
+ImageId: ami-04951cb9904e015b5 # custom image
 InstanceType: m6i.8xlarge # vCPU:32, GiB:128, $:1.92
 KeyName: dataforce-dev
 MaxCount: 1


### PR DESCRIPTION
In addition to having a custom docker image for docker runner (i.e. the one that executes commands from `.drone.yaml`) we can have a custom AMI which can be used for instantiating/running drone workers.

Having these images reduces startup time by ~2mins.